### PR TITLE
Role detail view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,13 +6,13 @@
       https://router.vuejs.org/guide/essentials/dynamic-matching.html#reacting-to-params-changes
       :key ensures component is always re-rendered from scratch,
       eliminating the need to watch routes or navigation guards in components -->
-      <router-view :key="$route.fullPath" />
+      <router-view />
     </v-content>
   </v-app>
 </template>
 
 <script>
-import TheAppBar from '@/components/TheAppBar.vue'
+import TheAppBar from "@/components/TheAppBar.vue";
 
 export default {
   name: "App",
@@ -20,10 +20,9 @@ export default {
     TheAppBar
   },
   data: () => ({
-    drawer: null, // vuetify determines initial state based on screen size
+    drawer: null // vuetify determines initial state based on screen size
   })
 };
 </script>
 
-<style lang="scss" scoped>
-</style>
+<style lang="scss" scoped></style>

--- a/src/components/FilterDrawer.vue
+++ b/src/components/FilterDrawer.vue
@@ -21,6 +21,7 @@
       </div>
       <v-btn text color="primary">Clear filters</v-btn>
     </div>
+
     <div class="px-4 py-5 pb-0">
       <div class="d-flex justify-space-between align-center">
         <span class="font-weight-bold">Search positions</span>
@@ -67,6 +68,11 @@
         label="Time Commitment"
       />
     </filter-section>
+    <!-- <flex-wrapper justifyContent="justify-end" classes="pa-2">
+      <v-btn to="/roles/new" dark color="primary"
+        ><v-icon>mdi-plus</v-icon> Create a new role</v-btn
+      >
+    </flex-wrapper> -->
   </div>
 </template>
 

--- a/src/components/layout/FlexWrapper.vue
+++ b/src/components/layout/FlexWrapper.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :class="
-      `flex flex-${direction === 'column' ? 'column' : 'row'} ${
+      `d-flex flex-${direction === 'column' ? 'column' : 'row'} ${
         !!justifyContent ? justifyContent : null
       }`
     "

--- a/src/components/layout/FlexWrapper.vue
+++ b/src/components/layout/FlexWrapper.vue
@@ -1,9 +1,9 @@
 <template>
   <div
     :class="
-      `d-flex flex-${direction === 'column' ? 'column' : 'row'} ${
-        !!justifyContent ? justifyContent : null
-      }`
+      `d-flex flex-${
+        direction === 'column' ? 'column' : 'row'
+      } ${justifyContent} ${classes}`
     "
   >
     <slot></slot>
@@ -17,7 +17,11 @@ export default {
       validator: value => ["column", "row"].includes(value),
       default: "row"
     },
-    justifyContent: { type: String }
+    justifyContent: { type: String, default: "flex-start" },
+    classes: {
+      type: String,
+      default: ""
+    }
   }
 };
 </script>

--- a/src/components/layout/MetaInfo.vue
+++ b/src/components/layout/MetaInfo.vue
@@ -1,0 +1,40 @@
+<template>
+  <dl class="detail">
+    <dt class="detail term">{{ title }}</dt>
+    <dd class="detail description">
+      {{ description }}
+    </dd>
+  </dl>
+</template>
+
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    description: {
+      type: String,
+      required: true
+    }
+  },
+  data() {
+    return {};
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.detail {
+  display: flex;
+  flex-flow: column;
+  margin: 0;
+  padding: 0;
+  &.term {
+    font-weight: bold;
+  }
+  &.description {
+  }
+}
+</style>

--- a/src/components/roles/RoleCard.vue
+++ b/src/components/roles/RoleCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-hover v-slot:default="{ hover }" class="pointer">
+  <v-hover v-slot:default="{ hover }">
     <v-card :elevation="hover ? 12 : 2" width="300" height="200" class="card">
       <div
         class="transition-wrapper d-flex flex-column full-height"
@@ -25,13 +25,11 @@
               >
               <span class="overline text-uppercase">hours / week</span>
             </span>
-            <span
-              class="primary--text caption text-uppercase button--text"
-              style="line-height: 1rem"
-              >Learn more</span
-            >
           </div>
         </div>
+        <v-btn text dark color="primary" :to="`roles/${role.id}`"
+          >Read More</v-btn
+        >
       </div>
     </v-card>
   </v-hover>

--- a/src/components/roles/RoleCard.vue
+++ b/src/components/roles/RoleCard.vue
@@ -25,11 +25,11 @@
               >
               <span class="overline text-uppercase">hours / week</span>
             </span>
+            <v-btn text dark color="primary" :to="`roles/view/${role.id}`"
+              >Read More</v-btn
+            >
           </div>
         </div>
-        <v-btn text dark color="primary" :to="`roles/${role.id}`"
-          >Read More</v-btn
-        >
       </div>
     </v-card>
   </v-hover>

--- a/src/components/roles/RoleViewDialog.vue
+++ b/src/components/roles/RoleViewDialog.vue
@@ -1,7 +1,9 @@
 <template
   ><div>
     <v-dialog
+      persistent
       @click:outside="$router.push('/roles')"
+      @keydown.escape="$router.push('/roles')"
       max-width="750"
       value="true"
     >
@@ -59,6 +61,9 @@ import FlexWrapper from "../layout/FlexWrapper";
 import MetaInfo from "../layout/MetaInfo";
 import { mapGetters } from "vuex";
 export default {
+  methods: {
+    log: e => console.log("ah", e)
+  },
   components: {
     FlexWrapper,
     MetaInfo
@@ -71,7 +76,6 @@ export default {
   computed: {
     ...mapGetters("roles", ["getByID"]),
     role: function() {
-      console.log(this.getByID(this.$route.params.id));
       return this.getByID(this.$route.params.id);
     }
   }

--- a/src/components/roles/RoleViewDialog.vue
+++ b/src/components/roles/RoleViewDialog.vue
@@ -1,0 +1,104 @@
+<template
+  ><div>
+    <v-dialog
+      @click:outside="$router.push('/roles')"
+      max-width="750"
+      value="true"
+    >
+      <v-card v-if="!!role" class="role card">
+        <v-card-title>
+          <flex-wrapper direction="column">
+            <h2 class="role title">{{ role.title }}</h2>
+            <flex-wrapper v-if="role.workingGroup || role.localGroup"
+              ><h5 class="role subtitle">
+                {{ !!role.workingGroup && role.workingGroup.text }}
+                <span
+                  v-if="!!role.workingGroup && !!role.localGroup"
+                  style="margin: 0 0.25rem;"
+                >
+                  -
+                </span>
+                {{ !!role.localGroup && role.localGroup.text }}
+              </h5>
+            </flex-wrapper>
+          </flex-wrapper>
+        </v-card-title>
+        <v-divider />
+        <v-card-text class="role text">
+          <flex-wrapper>
+            <div class="role description">
+              <p>{{ role.description }}</p>
+              <div v-if="!!role.responsibilities">
+                <h4>Responsibilities</h4>
+                <p>{{ role.responsibilities }}</p>
+              </div>
+            </div>
+            <div class="role sidebar">
+              <meta-info
+                v-if="!!role.timeCommitment"
+                title="Time Commitment"
+                :description="
+                  `${role.timeCommitment.min} -
+                ${role.timeCommitment.max} hours/week`
+                "
+              />
+              <meta-info
+                v-if="!!role.contactDetails"
+                title="Contact Details"
+                :description="role.contactDetails"
+              />
+            </div>
+          </flex-wrapper>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+<script>
+import FlexWrapper from "../layout/FlexWrapper";
+import MetaInfo from "../layout/MetaInfo";
+import { mapGetters } from "vuex";
+export default {
+  components: {
+    FlexWrapper,
+    MetaInfo
+  },
+  data() {
+    return {
+      dialog: true
+    };
+  },
+  computed: {
+    ...mapGetters("roles", ["getByID"]),
+    role: function() {
+      console.log(this.getByID(this.$route.params.id));
+      return this.getByID(this.$route.params.id);
+    }
+  }
+};
+</script>
+<style lang="scss" scoped>
+.role {
+  &.text {
+    margin-top: 1rem;
+    color: #222 !important;
+  }
+  &.title {
+    font-size: 1.5rem !important;
+    font-weight: bold;
+  }
+  &.subtitle {
+    font-weight: normal;
+  }
+
+  &.description {
+    flex-basis: 66%;
+    flex: 6;
+  }
+  &.sidebar {
+    margin-left: 1rem;
+    flex-basis: 33%;
+    flex: 3;
+  }
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,7 +1,8 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
 
-import Explore from "../views/Explore.vue";
+import RolesOverview from "../views/RolesOverview.vue";
+import RoleViewDialog from "../components/roles/RoleViewDialog.vue";
 // import UserProfile from "../views/UserProfile.vue";
 // import UserSettings from "../views/UserSettings.vue";
 // import GroupsOverview from "../views/GroupsOverview.vue";
@@ -13,10 +14,11 @@ Vue.use(VueRouter);
 
 const routes = [
   {
-    path: "/explore",
-    name: "explore",
-    component: Explore,
-    alias: "/"
+    path: "/roles",
+    name: "roles",
+    component: RolesOverview,
+    alias: "/",
+    children: [{ path: ":id", component: RoleViewDialog }]
   },
   // {
   //   path: "/user/:username",
@@ -65,8 +67,8 @@ const routes = [
   // },
   {
     // non-existent pages redirect to the home page
-    path: '*',
-    redirect: '/'
+    path: "*",
+    redirect: "/"
   }
 ];
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,7 +18,7 @@ const routes = [
     name: "roles",
     component: RolesOverview,
     alias: "/",
-    children: [{ path: ":id", component: RoleViewDialog }]
+    children: [{ path: "view/:id", component: RoleViewDialog }]
   },
   // {
   //   path: "/user/:username",

--- a/src/store/modules/roles.js
+++ b/src/store/modules/roles.js
@@ -11,7 +11,11 @@ export default {
         timeCommitment: {
           min: 6,
           max: 10
-        }
+        },
+        description:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        contactDetails: "An Email",
+        responsibilities: "Do cool things"
       },
       {
         id: 2,
@@ -22,7 +26,11 @@ export default {
         timeCommitment: {
           min: 6,
           max: 10
-        }
+        },
+        description:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        contactDetails: "An Email",
+        responsibilities: "Do cool things"
       },
       {
         id: 3,
@@ -33,7 +41,11 @@ export default {
         timeCommitment: {
           min: 1,
           max: 5
-        }
+        },
+        description:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        contactDetails: "An Email",
+        responsibilities: "Do cool things"
       },
       {
         id: 4,
@@ -44,7 +56,11 @@ export default {
         timeCommitment: {
           min: 11,
           max: 20
-        }
+        },
+        description:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        contactDetails: "An Email",
+        responsibilities: "Do cool things"
       },
       {
         id: 5,
@@ -55,7 +71,11 @@ export default {
         timeCommitment: {
           min: 21,
           max: 30
-        }
+        },
+        description:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        contactDetails: "An Email",
+        responsibilities: "Do cool things"
       },
       {
         id: 6,
@@ -66,7 +86,11 @@ export default {
         timeCommitment: {
           min: 6,
           max: 10
-        }
+        },
+        description:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        contactDetails: "An Email",
+        responsibilities: "Do cool things"
       }
     ],
     timeCommitment: { min: 1, max: 30 }
@@ -95,7 +119,8 @@ export default {
         }
         return true;
       });
-    }
+    },
+    getByID: state => id => state.roles.find(role => role.id == id)
   },
   actions: {}
 };

--- a/src/views/RolesOverview.vue
+++ b/src/views/RolesOverview.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <router-view :key="$route.fullPath" />
     <div :style="containerMargin">
       <div class>
         <div class="text-center my-8">
@@ -18,7 +19,7 @@
       </div>
       <div class="d-flex flex-wrap justify-center">
         <role-card v-for="role in filteredRoles" :key="role.id" :role="role" />
-        <div v-if="nPositions < 1" class="pa-5 text-center">
+        <div v-if="filteredRoles.length < 1" class="pa-5 text-center">
           <h3>No results.</h3>
           <p>Try removing filters.</p>
         </div>
@@ -35,7 +36,7 @@
 </template>
 
 <script>
-import RoleCard from "@/components/RoleCard.vue";
+import RoleCard from "@/components/roles/RoleCard.vue";
 import FilterDrawer from "@/components/FilterDrawer";
 import { mapGetters } from "vuex";
 


### PR DESCRIPTION
Added some basic navigation for viewing the roles. It uses some nested routing so you still have a dialog, but can also directly link to it when needed. Since there were some issues with the routing i laid out in #9, i used roles/view/:id for viewing a single role. We'll probably have to sit down and think of how we want to actually do routing to avoid conflicts since we also may want to do filtering in the url as well sometime in the future.
The dialog component looks at the :id parameter in the url, and uses that to look up the actual role. Right now from the store, later from the server.
resolves #2 