### PR TITLE
correct prettier parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "prettier": {
     "semi": true,
     "trailingComma": "es5",
-    "parser": "vue",
     "vueIndentScriptAndStyle": true
   },
   "eslintConfig": {


### PR DESCRIPTION
With the previous prettier configuration all `.js` files had the wrong format according to prettier.

<img width="1133" alt="Screenshot 2020-02-17 at 18 52 32" src="https://user-images.githubusercontent.com/15846595/74677003-9d692480-51b7-11ea-919e-972145cb2099.png">

When formatting the code using prettier it tried collapsing the entire object into a single line

<img width="584" alt="Screenshot 2020-02-17 at 18 52 55" src="https://user-images.githubusercontent.com/15846595/74677034-aa861380-51b7-11ea-819c-f3b134f988da.png">

This error was caused because the `parser` was set to `vue`.  According to [the prettier documentation](https://prettier.io/docs/en/options.html#parser):

> Prettier automatically infers the parser from the input file path, so you shouldn't have to change this setting.

By setting the parser to `vue` prettier tried formatting all files as `.vue` files. Now that this setting is removed, prettier correctly formats each file.