### PR TITLE
Task overview

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,11 +17,11 @@ import TheAppBar from "@/components/TheAppBar.vue";
 export default {
   name: "App",
   components: {
-    TheAppBar
+    TheAppBar,
   },
   data: () => ({
-    drawer: null // vuetify determines initial state based on screen size
-  })
+    drawer: null, // vuetify determines initial state based on screen size
+  }),
 };
 </script>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,10 +2,6 @@
   <v-app>
     <the-app-bar />
     <v-content>
-      <!-- Components do not automatically re-render with dynamic routes
-      https://router.vuejs.org/guide/essentials/dynamic-matching.html#reacting-to-params-changes
-      :key ensures component is always re-rendered from scratch,
-      eliminating the need to watch routes or navigation guards in components -->
       <router-view />
     </v-content>
   </v-app>

--- a/src/components/AutocompleteCustom.vue
+++ b/src/components/AutocompleteCustom.vue
@@ -27,18 +27,18 @@ export default {
   props: {
     items: {
       type: Array,
-      required: true
+      required: true,
     },
     value: {
       type: Array,
-      required: true
+      required: true,
     },
     label: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
-  data: () => ({})
+  data: () => ({}),
 };
 </script>
 

--- a/src/components/TheAppBar.vue
+++ b/src/components/TheAppBar.vue
@@ -18,8 +18,8 @@ export default {
   methods: {
     toggleDarkMode: function() {
       this.$vuetify.theme.dark = !this.$vuetify.theme.dark;
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/components/layout/DefaultDrawer.vue
+++ b/src/components/layout/DefaultDrawer.vue
@@ -31,50 +31,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.drawer {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  height: 100%;
-  width: 100%;
-  border-left-style: solid;
-  border-left-width: 1px;
-  z-index: 16;
-  transition: transform 0.3s ease-out;
-  overflow-y: auto;
-  transform: translateX(100%);
-  &.active {
-    transform: translateX(0);
-  }
-  .theme--light & {
-    background: white;
-    border-color: rgba(0, 0, 0, 0.12);
-  }
-  .theme--dark & {
-    background: #121212;
-    border-color: rgba(255, 255, 255, 0.12);
-  }
-
-  .drawer-header {
-    display: flex;
-    align-items: center;
-    border-bottom: 1px solid lightgray;
-    padding: 0.5rem;
-  }
-  .drawer-content {
-    padding: 0.5rem;
-  }
+.drawer-header {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid lightgray;
+  padding: 0.5rem;
 }
-
-.bottom-border {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  .theme--light & {
-    border-color: rgba(0, 0, 0, 0.12);
-  }
-  .theme--dark & {
-    border-color: rgba(255, 255, 255, 0.12);
-  }
+.drawer-content {
+  padding: 0.5rem;
 }
 </style>

--- a/src/components/layout/DefaultDrawer.vue
+++ b/src/components/layout/DefaultDrawer.vue
@@ -10,7 +10,7 @@
       <v-btn
         v-if="this.$vuetify.breakpoint.smAndDown"
         icon
-        @click="$emit('input', false)"
+        @click="$emit('close-drawer', false)"
       >
         <v-icon color="primary">
           mdi-arrow-left
@@ -34,8 +34,14 @@ export default {
 .drawer-header {
   display: flex;
   align-items: center;
-  border-bottom: 1px solid lightgray;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
   padding: 0.5rem;
+}
+
+.theme--dark {
+  .drawer-header {
+    border-color: rgba(255, 255, 255, 0.12);
+  }
 }
 .drawer-content {
   padding: 0.5rem;

--- a/src/components/layout/DefaultDrawer.vue
+++ b/src/components/layout/DefaultDrawer.vue
@@ -1,0 +1,80 @@
+<template>
+  <div>
+    <div
+      v-if="
+        (!!$slots.header && !!$slots.header[0]) ||
+          this.$vuetify.breakpoint.smAndDown
+      "
+      class="drawer-header"
+    >
+      <v-btn
+        v-if="this.$vuetify.breakpoint.smAndDown"
+        icon
+        @click="$emit('input', false)"
+      >
+        <v-icon color="primary">
+          mdi-arrow-left
+        </v-icon>
+      </v-btn>
+      <slot name="header" />
+    </div>
+    <div class="drawer-content">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "DefaultDrawer",
+};
+</script>
+
+<style lang="scss" scoped>
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  height: 100%;
+  width: 100%;
+  border-left-style: solid;
+  border-left-width: 1px;
+  z-index: 16;
+  transition: transform 0.3s ease-out;
+  overflow-y: auto;
+  transform: translateX(100%);
+  &.active {
+    transform: translateX(0);
+  }
+  .theme--light & {
+    background: white;
+    border-color: rgba(0, 0, 0, 0.12);
+  }
+  .theme--dark & {
+    background: #121212;
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+
+  .drawer-header {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid lightgray;
+    padding: 0.5rem;
+  }
+  .drawer-content {
+    padding: 0.5rem;
+  }
+}
+
+.bottom-border {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  .theme--light & {
+    border-color: rgba(0, 0, 0, 0.12);
+  }
+  .theme--dark & {
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+}
+</style>

--- a/src/components/layout/FilterDrawerSection.vue
+++ b/src/components/layout/FilterDrawerSection.vue
@@ -17,7 +17,7 @@
 <script>
 export default {
   name: "TheFilterDrawerSection",
-  data: () => ({})
+  data: () => ({}),
 };
 </script>
 

--- a/src/components/layout/FlexWrapper.vue
+++ b/src/components/layout/FlexWrapper.vue
@@ -15,13 +15,13 @@ export default {
   props: {
     direction: {
       validator: value => ["column", "row"].includes(value),
-      default: "row"
+      default: "row",
     },
     justifyContent: { type: String, default: "flex-start" },
     classes: {
       type: String,
-      default: ""
-    }
-  }
+      default: "",
+    },
+  },
 };
 </script>

--- a/src/components/layout/FlexWrapper.vue
+++ b/src/components/layout/FlexWrapper.vue
@@ -3,10 +3,10 @@
     :class="
       `d-flex flex-${
         direction === 'column' ? 'column' : 'row'
-      } ${justifyContent} ${classes}`
+      } justify-${justifyContent} ${classes}`
     "
   >
-    <slot></slot>
+    <slot />
   </div>
 </template>
 <script>

--- a/src/components/layout/GridList.vue
+++ b/src/components/layout/GridList.vue
@@ -8,11 +8,11 @@ export default {
   props: {
     itemWidth: {
       type: String,
-      required: true,
+      default: "300px",
     },
     itemHeight: {
       type: String,
-      required: true,
+      default: "200px",
     },
     gap: {
       type: String,

--- a/src/components/layout/GridList.vue
+++ b/src/components/layout/GridList.vue
@@ -33,9 +33,6 @@ export default {
 <style lang="scss" scoped>
 .grid-list {
   display: grid;
-  //   grid-template-columns: repeat(auto-fill, 300px);
-  //   grid-auto-rows: minmax(200px, max-content);
-  //   grid-gap: 1rem;
   align-items: start;
   justify-content: center;
 }

--- a/src/components/layout/GridList.vue
+++ b/src/components/layout/GridList.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="grid-list" :style="listStyle">
+    <slot />
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    itemWidth: {
+      type: String,
+      required: true,
+    },
+    itemHeight: {
+      type: String,
+      required: true,
+    },
+    gap: {
+      type: String,
+      default: "1rem",
+    },
+  },
+  computed: {
+    listStyle: function() {
+      return {
+        gridTemplateColumns: `repeat(auto-fill,${this.itemWidth})`,
+        gridAutoRows: `minmax(${this.itemHeight}, max-content)`,
+        gridGap: this.gap,
+      };
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+.grid-list {
+  display: grid;
+  //   grid-template-columns: repeat(auto-fill, 300px);
+  //   grid-auto-rows: minmax(200px, max-content);
+  //   grid-gap: 1rem;
+  align-items: start;
+  justify-content: center;
+}
+</style>

--- a/src/components/layout/MetaInfo.vue
+++ b/src/components/layout/MetaInfo.vue
@@ -12,16 +12,16 @@ export default {
   props: {
     title: {
       type: String,
-      required: true
+      required: true,
     },
     description: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
   data() {
     return {};
-  }
+  },
 };
 </script>
 

--- a/src/components/layout/PageWithDrawer.vue
+++ b/src/components/layout/PageWithDrawer.vue
@@ -3,12 +3,7 @@
     <div :style="containerMargin">
       <slot />
     </div>
-    <div
-      class="drawer"
-      :style="drawerStyle"
-      :class="{ active: isDrawerOpen }"
-      :value="isDrawerOpen"
-    >
+    <div class="drawer" :style="drawerStyle" :class="{ active: isDrawerOpen }">
       <slot name="drawer" />
     </div>
   </div>

--- a/src/components/layout/PageWithDrawer.vue
+++ b/src/components/layout/PageWithDrawer.vue
@@ -1,0 +1,80 @@
+<template>
+  <div>
+    <div :style="containerMargin">
+      <slot />
+    </div>
+    <div
+      class="drawer"
+      :style="drawerStyle"
+      :class="{ active: isDrawerOpen }"
+      :value="isDrawerOpen"
+    >
+      <slot name="drawer" />
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    isDrawerOpen: {
+      type: Boolean,
+      default: false,
+    },
+    drawerWidth: {
+      type: String,
+      default: "400px",
+    },
+  },
+  data: () => ({
+    drawer: null,
+    drawerWidth: 400,
+  }),
+  computed: {
+    isMobile: function() {
+      return this.$vuetify.breakpoint.smAndDown;
+    },
+    containerMargin: function() {
+      if (this.drawer && !this.isMobile) {
+        return { "margin-right": `${this.drawerWidth}px` };
+      }
+      return {};
+    },
+    drawerStyle: function() {
+      if (this.$vuetify.breakpoint.mdAndUp) {
+        return {
+          top: this.$store.state.styles.navbarHeight,
+          width: this.drawerWidth,
+        };
+      }
+      return {};
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  height: 100%;
+  width: 100%;
+  border-left-style: solid;
+  border-left-width: 1px;
+  z-index: 16;
+  transition: transform 0.3s ease-out;
+  overflow-y: auto;
+  transform: translateX(100%);
+  &.active {
+    transform: translateX(0);
+  }
+  .theme--light & {
+    background: white;
+    border-color: rgba(0, 0, 0, 0.12);
+  }
+  .theme--dark & {
+    background: #121212;
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+}
+</style>

--- a/src/components/layout/PageWithDrawer.vue
+++ b/src/components/layout/PageWithDrawer.vue
@@ -27,7 +27,6 @@ export default {
   },
   data: () => ({
     drawer: null,
-    drawerWidth: 400,
   }),
   computed: {
     isMobile: function() {
@@ -35,7 +34,7 @@ export default {
     },
     containerMargin: function() {
       if (this.drawer && !this.isMobile) {
-        return { "margin-right": `${this.drawerWidth}px` };
+        return { "margin-right": this.drawerWidth };
       }
       return {};
     },

--- a/src/components/layout/PageWithDrawer.vue
+++ b/src/components/layout/PageWithDrawer.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="my-8" :style="containerMargin">
+    <div :style="containerMargin">
       <slot />
     </div>
     <div

--- a/src/components/layout/PageWithDrawer.vue
+++ b/src/components/layout/PageWithDrawer.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div :style="containerMargin">
+    <div class="my-8" :style="containerMargin">
       <slot />
     </div>
     <div
@@ -25,16 +25,13 @@ export default {
       default: "400px",
     },
   },
-  data: () => ({
-    drawer: null,
-  }),
   computed: {
     isMobile: function() {
       return this.$vuetify.breakpoint.smAndDown;
     },
     containerMargin: function() {
-      if (this.drawer && !this.isMobile) {
-        return { "margin-right": this.drawerWidth };
+      if (this.isDrawerOpen && !this.isMobile) {
+        return { marginRight: this.drawerWidth };
       }
       return {};
     },

--- a/src/components/roles/RoleCard.vue
+++ b/src/components/roles/RoleCard.vue
@@ -7,7 +7,9 @@
       >
         <div class="d-flex justify-space-between align-center pa-3">
           <span>{{ role.workingGroup.text }}</span>
-          <v-icon color="primary">mdi-police-badge</v-icon>
+          <v-icon color="primary">
+            mdi-police-badge
+          </v-icon>
         </div>
         <v-divider />
         <div class="pa-3 d-flex flex-column flex-grow-1 justify-space-between">
@@ -19,15 +21,15 @@
           </div>
           <div class="d-flex flex-wrap justify-space-between align-end mt-5">
             <span class="d-flex flex-column justify-center">
-              <span class="title flex-grow-0" style="line-height: 1rem"
-                >{{ role.timeCommitment.min }} -
-                {{ role.timeCommitment.max }}</span
-              >
+              <span class="title flex-grow-0" style="line-height: 1rem">
+                {{ role.timeCommitment.min }} -
+                {{ role.timeCommitment.max }}
+              </span>
               <span class="overline text-uppercase">hours / week</span>
             </span>
-            <v-btn text dark color="primary" :to="`roles/view/${role.id}`"
-              >Read More</v-btn
-            >
+            <v-btn text dark color="primary" :to="`roles/view/${role.id}`">
+              Read More
+            </v-btn>
           </div>
         </div>
       </div>
@@ -36,14 +38,12 @@
 </template>
 
 <script>
-import has from "lodash/has";
-
 export default {
   name: "RoleCard",
   props: {
     role: {
       type: Object,
-      required: true
+      required: true,
       // might look into more managable prop validation, this might be hard to update when roles get more/less properties.
       // making components always render, even with missing properties might be okay
       // (i.e. the time commitment won't show when a role doesn't have a time commitment)
@@ -67,8 +67,8 @@ export default {
           Number.isInteger(obj.timeCommitment.max)
         );
       }*/
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/components/roles/RoleCard.vue
+++ b/src/components/roles/RoleCard.vue
@@ -1,45 +1,38 @@
 <template>
-  <v-hover v-slot:default="{ hover }">
-    <v-card :elevation="hover ? 12 : 2" width="300" height="200" class="card">
-      <div
-        class="transition-wrapper d-flex flex-column full-height"
-        :class="{ lighter: hover && $vuetify.theme.dark }"
-      >
-        <div class="d-flex justify-space-between align-center pa-3">
-          <span>{{ role.workingGroup.text }}</span>
-          <v-icon color="primary">
-            mdi-police-badge
-          </v-icon>
-        </div>
-        <v-divider />
-        <div class="pa-3 d-flex flex-column flex-grow-1 justify-space-between">
-          <div>
-            <h3>{{ role.title }}</h3>
-            <div class="caption">
-              {{ role.localGroup.text }}, {{ role.location }}
-            </div>
-          </div>
-          <div class="d-flex flex-wrap justify-space-between align-end mt-5">
-            <span class="d-flex flex-column justify-center">
-              <span class="title flex-grow-0" style="line-height: 1rem">
-                {{ role.timeCommitment.min }} -
-                {{ role.timeCommitment.max }}
-              </span>
-              <span class="overline text-uppercase">hours / week</span>
-            </span>
-            <v-btn text dark color="primary" :to="`roles/view/${role.id}`">
-              Read More
-            </v-btn>
-          </div>
-        </div>
-      </div>
-    </v-card>
-  </v-hover>
+  <default-card>
+    <template #header>
+      {{ role.workingGroup.text }}
+    </template>
+    <template #title>
+      {{ role.title }}
+    </template>
+    <template #subtitle>
+      {{ role.localGroup.text }}, {{ role.location }}
+    </template>
+    <template #meta>
+      <span class="d-flex flex-column justify-center">
+        <span class="title flex-grow-0" style="line-height: 1rem">
+          {{ role.timeCommitment.min }} -
+          {{ role.timeCommitment.max }}
+        </span>
+        <span class="overline text-uppercase">hours / week</span>
+      </span>
+    </template>
+    <template #action>
+      <v-btn text dark color="primary" :to="`roles/view/${role.id}`">
+        Read More
+      </v-btn>
+    </template>
+  </default-card>
 </template>
 
 <script>
+import DefaultCard from "@/components/surfaces/DefaultCard.vue";
 export default {
   name: "RoleCard",
+  components: {
+    DefaultCard,
+  },
   props: {
     role: {
       type: Object,
@@ -72,33 +65,4 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-.card {
-  margin: 0em 1em 2em 1em;
-  @media (max-width: "550px") {
-    margin-right: auto;
-    margin-left: auto;
-    margin-bottom: 1em;
-  }
-}
-
-.pointer:hover {
-  cursor: pointer;
-}
-
-.button--text:hover {
-  opacity: 0.7;
-}
-
-.transition-wrapper {
-  transition: background-color 280ms;
-}
-
-.lighter {
-  background-color: #333333 !important;
-}
-
-.full-height {
-  height: 100%;
-}
-</style>
+<style lang="scss" scoped></style>

--- a/src/components/roles/RoleFilters.vue
+++ b/src/components/roles/RoleFilters.vue
@@ -75,15 +75,4 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-.bottom-border {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  .theme--light & {
-    border-color: rgba(0, 0, 0, 0.12);
-  }
-  .theme--dark & {
-    border-color: rgba(255, 255, 255, 0.12);
-  }
-}
-</style>
+<style lang="scss" scoped></style>

--- a/src/components/roles/RoleFilters.vue
+++ b/src/components/roles/RoleFilters.vue
@@ -1,10 +1,5 @@
 <template>
-  <div
-    class="drawer"
-    :style="drawerStyle"
-    :class="{ active: value }"
-    :value="value"
-  >
+  <div>
     <div
       v-if="this.$vuetify.breakpoint.smAndDown"
       :style="{ height: $store.state.styles.navbarHeight }"
@@ -12,22 +7,26 @@
     >
       <div class="d-flex align-center">
         <v-btn icon @click="$emit('input', false)">
-          <v-icon color="primary">mdi-arrow-left</v-icon>
+          <v-icon color="primary">
+            mdi-arrow-left
+          </v-icon>
         </v-btn>
         <span>
           <strong class="primary--text">{{ roleAmount }}</strong>
           positions found
         </span>
       </div>
-      <v-btn text color="primary">Clear filters</v-btn>
+      <v-btn text color="primary">
+        Clear filters
+      </v-btn>
     </div>
 
     <div class="px-4 py-5 pb-0">
       <div class="d-flex justify-space-between align-center">
         <span class="font-weight-bold">Search positions</span>
-        <v-btn v-if="!$vuetify.breakpoint.smAndDown" text color="primary"
-          >Clear filters</v-btn
-        >
+        <v-btn v-if="!$vuetify.breakpoint.smAndDown" text color="primary">
+          Clear filters
+        </v-btn>
       </div>
       <v-text-field
         :value="selectedFilters.text"
@@ -37,9 +36,9 @@
       />
     </div>
     <filter-section>
-      <template v-slot:title
-        >Groups</template
-      >
+      <template v-slot:title>
+        Groups
+      </template>
       <flex-wrapper direction="column">
         <autocomplete-custom
           :value="selectedFilters.localGroup"
@@ -56,9 +55,9 @@
       </flex-wrapper>
     </filter-section>
     <filter-section>
-      <template v-slot:title
-        >Time commitment</template
-      >
+      <template v-slot:title>
+        Time commitment
+      </template>
       <v-range-slider
         v-model="timeRange"
         :min="timeCommitment.min"
@@ -68,60 +67,38 @@
         label="Time Commitment"
       />
     </filter-section>
-    <!-- <flex-wrapper justifyContent="justify-end" classes="pa-2">
-      <v-btn to="/roles/new" dark color="primary"
-        ><v-icon>mdi-plus</v-icon> Create a new role</v-btn
-      >
-    </flex-wrapper> -->
   </div>
 </template>
 
 <script>
 import FlexWrapper from "@/components/layout/FlexWrapper.vue";
 import AutocompleteCustom from "@/components/AutocompleteCustom";
-import { mapState, mapGetters, mapMutations } from "vuex";
-import FilterDrawerSection from "./layout/FilterDrawerSection";
+import { mapState } from "vuex";
+import FilterDrawerSection from "../layout/FilterDrawerSection";
 
 export default {
-  name: "TheFilterDrawer",
+  name: "RoleFilters",
   components: {
     filterSection: FilterDrawerSection,
     AutocompleteCustom,
-    FlexWrapper
+    FlexWrapper,
   },
   props: {
-    value: {
-      required: true,
-      validator: value => typeof value === "boolean" || value === null
-    },
     selectedFilters: {
       type: Object,
-      required: true
+      required: true,
     },
     roleAmount: { type: Number, default: 0 },
     onSetFilter: { required: true, type: Function },
-    width: {
-      required: true,
-      type: Number,
-      default: 400
-    }
   },
   data: () => ({
-    timeRange: [1, 30]
+    timeRange: [1, 30],
   }),
   computed: {
     ...mapState("roles", ["timeCommitment"]),
     ...mapState("localGroups", ["localGroups"]),
     ...mapState("workingGroups", ["workingGroups"]),
-    drawerStyle: function() {
-      let styles = {};
-      if (!this.$vuetify.breakpoint.smAndDown) {
-        styles.top = this.$store.state.styles.navbarHeight;
-        styles["max-width"] = this.width + "px";
-      }
-      return styles;
-    }
-  }
+  },
 };
 </script>
 

--- a/src/components/roles/RoleViewDialog.vue
+++ b/src/components/roles/RoleViewDialog.vue
@@ -1,5 +1,5 @@
-<template
-  ><div>
+<template>
+  <div>
     <v-dialog
       persistent
       @click:outside="$router.push('/roles')"
@@ -11,8 +11,8 @@
         <v-card-title>
           <flex-wrapper direction="column">
             <h2 class="role title">{{ role.title }}</h2>
-            <flex-wrapper v-if="role.workingGroup || role.localGroup"
-              ><h5 class="role subtitle">
+            <flex-wrapper v-if="role.workingGroup || role.localGroup">
+              <h5 class="role subtitle">
                 {{ !!role.workingGroup && role.workingGroup.text }}
                 <span
                   v-if="!!role.workingGroup && !!role.localGroup"
@@ -61,24 +61,21 @@ import FlexWrapper from "../layout/FlexWrapper";
 import MetaInfo from "../layout/MetaInfo";
 import { mapGetters } from "vuex";
 export default {
-  methods: {
-    log: e => console.log("ah", e)
-  },
   components: {
     FlexWrapper,
-    MetaInfo
+    MetaInfo,
   },
   data() {
     return {
-      dialog: true
+      dialog: true,
     };
   },
   computed: {
     ...mapGetters("roles", ["getByID"]),
     role: function() {
       return this.getByID(this.$route.params.id);
-    }
-  }
+    },
+  },
 };
 </script>
 <style lang="scss" scoped>

--- a/src/components/roles/RoleViewDialog.vue
+++ b/src/components/roles/RoleViewDialog.vue
@@ -101,5 +101,11 @@ export default {
     flex-basis: 33%;
     flex: 3;
   }
+
+  &.theme--dark {
+    .text {
+      color: white !important;
+    }
+  }
 }
 </style>

--- a/src/components/surfaces/DefaultCard.vue
+++ b/src/components/surfaces/DefaultCard.vue
@@ -1,7 +1,10 @@
 <template>
   <v-hover v-slot:default="{ hover }">
     <v-card :elevation="hover ? 12 : 2" width="300" height="200" class="card">
-      <div class="transition-wrapper d-flex flex-column full-height">
+      <div
+        class="transition-wrapper d-flex flex-column full-height"
+        :class="{ lighter: hover && $vuetify.theme.dark }"
+      >
         <template v-if="!!$slots.header && !!$slots.header[0]">
           <div class="d-flex align-center pa-3">
             <slot name="header" />
@@ -14,9 +17,12 @@
             <div class="caption">
               <slot name="subtitle" />
             </div>
-            <div v-if="!!$slots.content && !!$slots.content[0]" class="pa-3">
+            <v-card-text
+              v-if="!!$slots.content && !!$slots.content[0]"
+              class="pa-3"
+            >
               <slot name="content" />
-            </div>
+            </v-card-text>
           </div>
           <div class="d-flex flex-wrap justify-space-between align-end mt-5">
             <span class="d-flex flex-column justify-center">
@@ -38,5 +44,11 @@ export default {};
 <style lang="scss" scoped>
 .full-height {
   height: 100%;
+}
+.transition-wrapper {
+  transition: background-color 280ms;
+}
+.lighter {
+  background-color: #333333 !important;
 }
 </style>

--- a/src/components/surfaces/DefaultCard.vue
+++ b/src/components/surfaces/DefaultCard.vue
@@ -1,10 +1,7 @@
 <template>
   <v-hover v-slot:default="{ hover }">
     <v-card :elevation="hover ? 12 : 2" width="300" height="200" class="card">
-      <div
-        class="transition-wrapper d-flex flex-column full-height"
-        :class="{ lighter: hover && $vuetify.theme.dark }"
-      >
+      <div class="transition-wrapper d-flex flex-column full-height">
         <template v-if="!!$slots.header && !!$slots.header[0]">
           <div class="d-flex align-center pa-3">
             <slot name="header" />
@@ -39,10 +36,6 @@
 export default {};
 </script>
 <style lang="scss" scoped>
-.lighter {
-  background-color: #333333 !important;
-}
-
 .full-height {
   height: 100%;
 }

--- a/src/components/surfaces/DefaultCard.vue
+++ b/src/components/surfaces/DefaultCard.vue
@@ -1,0 +1,49 @@
+<template>
+  <v-hover v-slot:default="{ hover }">
+    <v-card :elevation="hover ? 12 : 2" width="300" height="200" class="card">
+      <div
+        class="transition-wrapper d-flex flex-column full-height"
+        :class="{ lighter: hover && $vuetify.theme.dark }"
+      >
+        <template v-if="!!$slots.header && !!$slots.header[0]">
+          <div class="d-flex align-center pa-3">
+            <slot name="header" />
+          </div>
+          <v-divider />
+        </template>
+        <div class="pa-3 d-flex flex-column justify-space-between flex-grow-1">
+          <div>
+            <h3><slot name="title" /></h3>
+            <div class="caption">
+              <slot name="subtitle" />
+            </div>
+            <div v-if="!!$slots.content && !!$slots.content[0]" class="pa-3">
+              <slot name="content" />
+            </div>
+          </div>
+          <div class="d-flex flex-wrap justify-space-between align-end mt-5">
+            <span class="d-flex flex-column justify-center">
+              <slot name="meta" />
+            </span>
+            <div>
+              <slot name="action" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </v-card>
+  </v-hover>
+</template>
+
+<script>
+export default {};
+</script>
+<style lang="scss" scoped>
+.lighter {
+  background-color: #333333 !important;
+}
+
+.full-height {
+  height: 100%;
+}
+</style>

--- a/src/components/tasks/TaskCard.vue
+++ b/src/components/tasks/TaskCard.vue
@@ -1,0 +1,34 @@
+<template>
+  <default-card>
+    <template #title>{{ task.title }}</template>
+    <template #subtitle>
+      {{ task.localGroup.text }}, {{ task.workingGroup.text }}
+    </template>
+    <template #meta>
+      <span class="d-flex flex-column justify-center">
+        <span class="title flex-grow-0" style="line-height: 1rem">
+          {{ task.timeCommitment.min }} -
+          {{ task.timeCommitment.max }}
+        </span>
+        <span class="overline text-uppercase">hours</span>
+      </span>
+    </template>
+    <template #action>
+      <v-btn text dark color="primary">
+        Read More
+      </v-btn>
+    </template>
+  </default-card>
+</template>
+<script>
+import DefaultCard from "@/components/surfaces/DefaultCard.vue";
+export default {
+  components: { DefaultCard },
+  props: {
+    task: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>

--- a/src/components/tasks/TaskCard.vue
+++ b/src/components/tasks/TaskCard.vue
@@ -1,6 +1,8 @@
 <template>
   <default-card>
-    <template #title>{{ task.title }}</template>
+    <template #title>
+      {{ task.title }}
+    </template>
     <template #subtitle>
       {{ task.localGroup.text }}, {{ task.workingGroup.text }}
     </template>

--- a/src/components/tasks/TaskFilters.vue
+++ b/src/components/tasks/TaskFilters.vue
@@ -76,15 +76,4 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-.bottom-border {
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
-  .theme--light & {
-    border-color: rgba(0, 0, 0, 0.12);
-  }
-  .theme--dark & {
-    border-color: rgba(255, 255, 255, 0.12);
-  }
-}
-</style>
+<style lang="scss" scoped></style>

--- a/src/components/tasks/TaskFilters.vue
+++ b/src/components/tasks/TaskFilters.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- Right now, this is the exact same as RoleFilters.vue, it could be that they will diverge at some point though, so for now there's two seperate files -->
   <div>
     <div>
       <v-text-field

--- a/src/components/tasks/TaskFilters.vue
+++ b/src/components/tasks/TaskFilters.vue
@@ -4,7 +4,7 @@
     <div>
       <v-text-field
         :value="selectedFilters.text"
-        label="Facilitator, Writer, Photographer..."
+        label="Poster design, Outreach, Photographer..."
         class="mt-3"
         @input="value => onSetFilter(value, 'text')"
       />
@@ -51,7 +51,7 @@ import { mapState } from "vuex";
 import FilterDrawerSection from "../layout/FilterDrawerSection";
 
 export default {
-  name: "RoleFilters",
+  name: "TaskFilters",
   components: {
     filterSection: FilterDrawerSection,
     AutocompleteCustom,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import VueRouter from "vue-router";
 
 import RolesOverview from "../views/RolesOverview.vue";
 import RoleViewDialog from "../components/roles/RoleViewDialog.vue";
+import TasksOverview from "../views/TaskOverview.vue";
 // import UserProfile from "../views/UserProfile.vue";
 // import UserSettings from "../views/UserSettings.vue";
 // import GroupsOverview from "../views/GroupsOverview.vue";
@@ -18,7 +19,12 @@ const routes = [
     name: "roles",
     component: RolesOverview,
     alias: "/",
-    children: [{ path: "view/:id", component: RoleViewDialog }]
+    children: [{ path: "view/:id", component: RoleViewDialog }],
+  },
+  {
+    path: "/tasks",
+    name: "tasksOverview",
+    component: TasksOverview,
   },
   // {
   //   path: "/user/:username",
@@ -68,14 +74,14 @@ const routes = [
   {
     // non-existent pages redirect to the home page
     path: "*",
-    redirect: "/"
-  }
+    redirect: "/",
+  },
 ];
 
 const router = new VueRouter({
   mode: "history",
   base: process.env.BASE_URL,
-  routes
+  routes,
 });
 
 export default router;

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -1,43 +1,115 @@
-import findWithIndex from '@/utils/findWithIndex'
+import findWithIndex from "@/utils/findWithIndex";
 
 export default {
   state: {
     tasks: [
-      {id: 1, title: 'task 1', completed: true, groupId: 1, sectionId: 1},
-      {id: 2, title: 'task 2', completed: false, groupId: 1, sectionId: 1},
-      {id: 3, title: 'task 3', completed: false, groupId: 1, sectionId: 2},
-      {id: 4, title: 'task 4', completed: false, groupId: 1, sectionId: 2}
-    ]
+      {
+        id: 1,
+        title: "Make posters for an upcoming action",
+        completed: true,
+        // TEMP: same with roles, everything will be done on the serverside, just here for demo purposes
+        workingGroup: { text: "Political Strategy", value: 3 },
+        localGroup: { text: "XR Amsterdam", value: 1 },
+        description:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        timeCommitment: {
+          min: 6,
+          max: 10,
+        },
+      },
+      {
+        id: 2,
+        title: "We need a photographer!",
+        completed: false,
+        workingGroup: { text: "Finance", value: 7 },
+        localGroup: { text: "XR NL", value: 20 },
+        description:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        timeCommitment: {
+          min: 1,
+          max: 5,
+        },
+      },
+      {
+        id: 3,
+        title:
+          "Can someone help me bake a cake? (it's for an action, i promise)",
+        completed: false,
+        workingGroup: { text: "Action and Logistics", value: 5 },
+        localGroup: { text: "XR Den Haag", value: 6 },
+        description:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        timeCommitment: {
+          min: 11,
+          max: 20,
+        },
+      },
+      {
+        id: 4,
+        title: "Give a talk at this cool location.",
+        completed: false,
+        workingGroup: { text: "Action and Logistics", value: 5 },
+        localGroup: { text: "XR Zwolle", value: 19 },
+        description:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+        timeCommitment: {
+          min: 21,
+          max: 30,
+        },
+      },
+    ],
   },
   getters: {
-    tasksUncomplete: state => state.tasks.filter(task => !task.completed),
-    getTask: (state) => (id) => state.tasks.find(task => task.id === id)
+    getByFilters: state => ({ text, workingGroup, localGroup }) => {
+      // need to make this more resilient and generic, this will get out of hand quickly, but ok for testing
+      return state.tasks.filter(task => {
+        if (
+          text !== "" &&
+          !task.title.toLowerCase().includes(text.toLowerCase())
+        ) {
+          return false;
+        }
+        if (
+          workingGroup.length > 0 &&
+          !workingGroup.includes(task.workingGroup.value)
+        ) {
+          return false;
+        }
+        if (
+          localGroup.length > 0 &&
+          !localGroup.includes(task.localGroup.value)
+        ) {
+          return false;
+        }
+        return true;
+      });
+    },
+    getByID: state => id => state.tasks.find(task => task.id == id),
   },
   mutations: {
-    addTask (state, { title, groupId, sectionId }) {
+    addTask(state, { title, groupId }) {
       // TODO: obtain new task id from db (in an action instead of mutation)
-      const newId = state.tasks[state.tasks.length - 1].id + 1
-      state.tasks.push({id: newId, title: title, groupId: groupId, sectionId: sectionId})
+      const newId = state.tasks[state.tasks.length - 1].id + 1;
+      state.tasks.push({
+        id: newId,
+        title: title,
+        groupId: groupId,
+      });
     },
-    deleteTask (state, id) {
-      const {_, index} = findWithIndex(state.tasks, id)
-      state.tasks.splice(index, 1)
+    deleteTask(state, id) {
+      const { index } = findWithIndex(state.tasks, id);
+      state.tasks.splice(index, 1);
     },
-    toggleTask (state, id) {
-      const {item:task, index} = findWithIndex(state.tasks, id)
-      task.completed = !task.completed
-      state.tasks.splice(index, 1, task)
+    toggleTask(state, id) {
+      const { item: task, index } = findWithIndex(state.tasks, id);
+      task.completed = !task.completed;
+      state.tasks.splice(index, 1, task);
     },
-    setTaskTitle (state, { id, title }) {
-      const {item:task, index} = findWithIndex(state.tasks, id)
-      task.title = title
-      state.tasks.splice(index, 1, task)
-    },
-    setTaskSection (state, { id, sectionId }) {
-      const {item:task, index} = findWithIndex(state.tasks, id)
-      task.sectionId = sectionId
-      state.tasks.splice(index, 1, task)
+    setTaskTitle(state, { id, title }) {
+      const { item: task, index } = findWithIndex(state.tasks, id);
+      task.title = title;
+      state.tasks.splice(index, 1, task);
     },
   },
   actions: {},
-}
+};

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,2 +1,6 @@
 // styles in this file are available from all components
-@import 'base/typography';
+@import "base/typography";
+
+.xr-title {
+  font-family: "FUCXEDCAPS";
+}

--- a/src/views/RolesOverview.vue
+++ b/src/views/RolesOverview.vue
@@ -18,12 +18,7 @@
       </div>
       <v-divider />
     </div>
-    <grid-list
-      v-if="filteredRoles.length > 0"
-      item-width="300px"
-      item-height="200px"
-      gap="2rem"
-    >
+    <grid-list v-if="filteredRoles.length > 0" gap="2rem">
       <role-card v-for="role in filteredRoles" :key="role.id" :role="role" />
     </grid-list>
     <div v-else class="pa-5 text-center">
@@ -31,13 +26,20 @@
       <p>Try removing filters.</p>
     </div>
     <template v-slot:drawer>
-      <default-drawer>
+      <default-drawer @close-drawer="handleCloseDrawer">
         <template #header>
           <div
             class="d-flex justify-space-between align-center"
             style="width:100%;"
           >
-            <span class="font-weight-bold">Search for positions</span>
+            <div class="d-flex flex-column">
+              <span class="font-weight-bold">
+                Search for positions
+              </span>
+              <span class="font-weight-light">
+                ({{ filteredRoles.length }} positions found)
+              </span>
+            </div>
             <v-btn text color="primary">
               Clear filters
             </v-btn>
@@ -99,6 +101,9 @@ export default {
   methods: {
     handleSelectFilter: function(value, type) {
       this.selectedFilters[type] = value;
+    },
+    handleCloseDrawer: function() {
+      this.isDrawerOpen = false;
     },
   },
 };

--- a/src/views/RolesOverview.vue
+++ b/src/views/RolesOverview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <page-with-drawer :is-drawer-open="isDrawerOpen">
     <router-view :key="$route.fullPath" />
     <div :style="containerMargin">
       <div class>
@@ -12,7 +12,9 @@
         <div v-if="$vuetify.breakpoint.smAndDown" class="mb-8">
           <v-divider />
           <div class="d-flex justify-end pa-3">
-            <v-btn text color="primary" @click="drawer = true">Filter</v-btn>
+            <v-btn text color="primary" @click="isDrawerOpen = true">
+              Filter
+            </v-btn>
           </div>
           <v-divider />
         </div>
@@ -25,36 +27,38 @@
         </div>
       </div>
     </div>
-    <filter-drawer
-      v-model="drawer"
-      :width="drawerWidth"
-      :onSetFilter="handleSelectFilter"
-      :selectedFilters="selectedFilters"
-      :roleAmount="filteredRoles.length"
-    />
-  </div>
+    <template v-slot:drawer>
+      <role-filters
+        :onSetFilter="handleSelectFilter"
+        :selectedFilters="selectedFilters"
+        :roleAmount="filteredRoles.length"
+      />
+    </template>
+  </page-with-drawer>
 </template>
 
 <script>
+import PageWithDrawer from "@/components/layout/PageWithDrawer.vue";
 import RoleCard from "@/components/roles/RoleCard.vue";
-import FilterDrawer from "@/components/FilterDrawer";
+import RoleFilters from "@/components/roles/RoleFilters.vue";
 import { mapGetters } from "vuex";
 
 export default {
   name: "Explore",
   components: {
     RoleCard,
-    FilterDrawer
+    RoleFilters,
+    PageWithDrawer,
   },
   data: () => ({
-    drawer: null,
+    isDrawerOpen: null,
     drawerWidth: 400,
     //not a huge fan of having to declare these beforehand, will look into another way
     selectedFilters: {
       text: "",
       localGroup: [],
-      workingGroup: []
-    }
+      workingGroup: [],
+    },
   }),
   computed: {
     ...mapGetters("roles", ["getByFilters"]),
@@ -62,7 +66,7 @@ export default {
       return this.getByFilters(this.selectedFilters);
     },
     containerMargin: function() {
-      if (this.drawer && !this.isMobile) {
+      if (this.isDrawerOpen && !this.isMobile) {
         return { "margin-right": this.drawerWidth + "px" };
       } else {
         return {};
@@ -70,21 +74,21 @@ export default {
     },
     isMobile: function() {
       return this.$vuetify.breakpoint.smAndDown;
-    }
+    },
   },
   methods: {
     handleSelectFilter: function(value, type) {
       this.selectedFilters[type] = value;
-    }
+    },
   },
   watch: {
     isMobile: function() {
-      this.drawer = !this.isMobile;
-    }
+      this.isDrawerOpen = !this.isMobile;
+    },
   },
   created: function() {
-    this.drawer = !this.isMobile;
-  }
+    this.isDrawerOpen = !this.isMobile;
+  },
 };
 </script>
 

--- a/src/views/RolesOverview.vue
+++ b/src/views/RolesOverview.vue
@@ -1,45 +1,61 @@
 <template>
   <page-with-drawer :is-drawer-open="isDrawerOpen">
     <router-view :key="$route.fullPath" />
-    <div :style="containerMargin">
-      <div class>
-        <div class="text-center my-8">
-          <h1>
-            Find positions at
-            <span class="xr-title">Extinction Rebellion Nederland.</span>
-          </h1>
-        </div>
-        <div v-if="$vuetify.breakpoint.smAndDown" class="mb-8">
-          <v-divider />
-          <div class="d-flex justify-end pa-3">
-            <v-btn text color="primary" @click="isDrawerOpen = true">
-              Filter
-            </v-btn>
-          </div>
-          <v-divider />
-        </div>
+    <div class="text-center">
+      <h1>
+        Find roles at
+        <span class="xr-title">Extinction Rebellion Nederland.</span>
+      </h1>
+    </div>
+    <div v-if="$vuetify.breakpoint.smAndDown" class="mb-8">
+      <v-divider />
+      <div class="d-flex justify-end pa-3">
+        <v-btn text color="primary" @click="isDrawerOpen = true">
+          Filter
+        </v-btn>
       </div>
-      <div class="d-flex flex-wrap justify-center">
-        <role-card v-for="role in filteredRoles" :key="role.id" :role="role" />
-        <div v-if="filteredRoles.length < 1" class="pa-5 text-center">
-          <h3>No results.</h3>
-          <p>Try removing filters.</p>
-        </div>
-      </div>
+      <v-divider />
+    </div>
+    <grid-list
+      v-if="filteredRoles.length > 0"
+      item-width="300px"
+      item-height="200px"
+      gap="2rem"
+    >
+      <role-card v-for="role in filteredRoles" :key="role.id" :role="role" />
+    </grid-list>
+    <div v-else class="pa-5 text-center">
+      <h3>No results.</h3>
+      <p>Try removing filters.</p>
     </div>
     <template v-slot:drawer>
-      <role-filters
-        :on-set-filter="handleSelectFilter"
-        :selected-filters="selectedFilters"
-        :role-amount="filteredRoles.length"
-      />
+      <default-drawer>
+        <template #header>
+          <div
+            class="d-flex justify-space-between align-center"
+            style="width:100%;"
+          >
+            <span class="font-weight-bold">Search for positions</span>
+            <v-btn text color="primary">
+              Clear filters
+            </v-btn>
+          </div>
+        </template>
+        <role-filters
+          :on-set-filter="handleSelectFilter"
+          :selected-filters="selectedFilters"
+          :role-amount="filteredRoles.length"
+        />
+      </default-drawer>
     </template>
   </page-with-drawer>
 </template>
 
 <script>
+import DefaultDrawer from "@/components/layout/DefaultDrawer.vue";
 import PageWithDrawer from "@/components/layout/PageWithDrawer.vue";
 import RoleCard from "@/components/roles/RoleCard.vue";
+import GridList from "@/components/layout/GridList.vue";
 import RoleFilters from "@/components/roles/RoleFilters.vue";
 import { mapGetters } from "vuex";
 
@@ -49,10 +65,11 @@ export default {
     RoleCard,
     RoleFilters,
     PageWithDrawer,
+    GridList,
+    DefaultDrawer,
   },
   data: () => ({
     isDrawerOpen: null,
-    drawerWidth: 400,
     //not a huge fan of having to declare these beforehand, will look into another way
     selectedFilters: {
       text: "",
@@ -64,13 +81,6 @@ export default {
     ...mapGetters("roles", ["getByFilters"]),
     filteredRoles: function() {
       return this.getByFilters(this.selectedFilters);
-    },
-    containerMargin: function() {
-      if (this.isDrawerOpen && !this.isMobile) {
-        return { "margin-right": this.drawerWidth + "px" };
-      } else {
-        return {};
-      }
     },
     isMobile: function() {
       return this.$vuetify.breakpoint.smAndDown;

--- a/src/views/RolesOverview.vue
+++ b/src/views/RolesOverview.vue
@@ -29,9 +29,9 @@
     </div>
     <template v-slot:drawer>
       <role-filters
-        :onSetFilter="handleSelectFilter"
-        :selectedFilters="selectedFilters"
-        :roleAmount="filteredRoles.length"
+        :on-set-filter="handleSelectFilter"
+        :selected-filters="selectedFilters"
+        :role-amount="filteredRoles.length"
       />
     </template>
   </page-with-drawer>
@@ -44,7 +44,7 @@ import RoleFilters from "@/components/roles/RoleFilters.vue";
 import { mapGetters } from "vuex";
 
 export default {
-  name: "Explore",
+  name: "RolesOverview",
   components: {
     RoleCard,
     RoleFilters,
@@ -76,11 +76,6 @@ export default {
       return this.$vuetify.breakpoint.smAndDown;
     },
   },
-  methods: {
-    handleSelectFilter: function(value, type) {
-      this.selectedFilters[type] = value;
-    },
-  },
   watch: {
     isMobile: function() {
       this.isDrawerOpen = !this.isMobile;
@@ -88,6 +83,11 @@ export default {
   },
   created: function() {
     this.isDrawerOpen = !this.isMobile;
+  },
+  methods: {
+    handleSelectFilter: function(value, type) {
+      this.selectedFilters[type] = value;
+    },
   },
 };
 </script>

--- a/src/views/RolesOverview.vue
+++ b/src/views/RolesOverview.vue
@@ -1,10 +1,12 @@
 <template>
   <page-with-drawer :is-drawer-open="isDrawerOpen">
     <router-view :key="$route.fullPath" />
-    <div class="text-center">
+    <div class="text-center my-8">
       <h1>
         Find roles at
-        <span class="xr-title">Extinction Rebellion Nederland.</span>
+        <strong class="xr-title">
+          Extinction Rebellion Nederland.
+        </strong>
       </h1>
     </div>
     <div v-if="$vuetify.breakpoint.smAndDown" class="mb-8">
@@ -102,8 +104,4 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-.xr-title {
-  font-family: "FUCXEDCAPS";
-}
-</style>
+<style lang="scss" scoped></style>

--- a/src/views/TaskOverview.vue
+++ b/src/views/TaskOverview.vue
@@ -1,5 +1,5 @@
 <template>
-  <page-with-drawer>
+  <page-with-drawer :is-drawer-open="isDrawerOpen">
     😎
     <template slot:drawer>
       ☜(ﾟヮﾟ☜)
@@ -8,7 +8,28 @@
 </template>
 <script>
 import PageWithDrawer from "@/components/layout/PageWithDrawer.vue";
+import { mapGetters } from "vuex";
 export default {
   components: PageWithDrawer,
+  data: () => ({
+    isDrawerOpen: null,
+  }),
+  computed: {
+    ...mapGetters("tasks", ["getByFilters"]),
+    filteredRoles: function() {
+      return this.getByFilters(this.selectedFilters);
+    },
+    isMobile: function() {
+      return this.$vuetify.breakpoint.smAndDown;
+    },
+  },
+  watch: {
+    isMobile: function() {
+      this.isDrawerOpen = !this.isMobile;
+    },
+  },
+  created: function() {
+    this.isDrawerOpen = !this.isMobile;
+  },
 };
 </script>

--- a/src/views/TaskOverview.vue
+++ b/src/views/TaskOverview.vue
@@ -1,7 +1,7 @@
 <template>
   <page-with-drawer :is-drawer-open="isDrawerOpen">
     😎
-    <template slot:drawer>
+    <template v-slot:drawer>
       ☜(ﾟヮﾟ☜)
     </template>
   </page-with-drawer>
@@ -10,7 +10,8 @@
 import PageWithDrawer from "@/components/layout/PageWithDrawer.vue";
 import { mapGetters } from "vuex";
 export default {
-  components: PageWithDrawer,
+  name: "TasksOverview",
+  components: { PageWithDrawer },
   data: () => ({
     isDrawerOpen: null,
   }),

--- a/src/views/TaskOverview.vue
+++ b/src/views/TaskOverview.vue
@@ -1,0 +1,14 @@
+<template>
+  <page-with-drawer>
+    😎
+    <template slot:drawer>
+      ☜(ﾟヮﾟ☜)
+    </template>
+  </page-with-drawer>
+</template>
+<script>
+import PageWithDrawer from "@/components/layout/PageWithDrawer.vue";
+export default {
+  components: PageWithDrawer,
+};
+</script>

--- a/src/views/TaskOverview.vue
+++ b/src/views/TaskOverview.vue
@@ -1,23 +1,66 @@
 <template>
   <page-with-drawer :is-drawer-open="isDrawerOpen">
-    😎
+    <grid-list
+      v-if="filteredTasks.length > 0"
+      item-width="300px"
+      item-height="200px"
+      gap="2rem"
+    >
+      <task-card v-for="task in filteredTasks" :key="task.id" :task="task" />
+    </grid-list>
+    <div v-else class="pa-5 text-center">
+      <h3>No results.</h3>
+      <p>Try removing filters.</p>
+    </div>
     <template v-slot:drawer>
-      ☜(ﾟヮﾟ☜)
+      <default-drawer>
+        <template #header>
+          <div
+            class="d-flex justify-space-between align-center"
+            style="width:100%;"
+          >
+            <span class="font-weight-bold">Search for positions</span>
+            <v-btn text color="primary">
+              Clear filters
+            </v-btn>
+          </div>
+        </template>
+        <task-filters
+          :on-set-filter="handleSelectFilter"
+          :selected-filters="selectedFilters"
+          :role-amount="filteredTasks.length"
+        />
+      </default-drawer>
     </template>
   </page-with-drawer>
 </template>
 <script>
+import TaskFilters from "@/components/tasks/TaskFilters.vue";
+import DefaultDrawer from "@/components/layout/DefaultDrawer.vue";
+import GridList from "@/components/layout/GridList.vue";
+import TaskCard from "@/components/tasks/TaskCard.vue";
 import PageWithDrawer from "@/components/layout/PageWithDrawer.vue";
 import { mapGetters } from "vuex";
 export default {
   name: "TasksOverview",
-  components: { PageWithDrawer },
+  components: {
+    TaskFilters,
+    PageWithDrawer,
+    GridList,
+    TaskCard,
+    DefaultDrawer,
+  },
   data: () => ({
     isDrawerOpen: null,
+    selectedFilters: {
+      text: "",
+      localGroup: [],
+      workingGroup: [],
+    },
   }),
   computed: {
     ...mapGetters("tasks", ["getByFilters"]),
-    filteredRoles: function() {
+    filteredTasks: function() {
       return this.getByFilters(this.selectedFilters);
     },
     isMobile: function() {
@@ -31,6 +74,11 @@ export default {
   },
   created: function() {
     this.isDrawerOpen = !this.isMobile;
+  },
+  methods: {
+    handleSelectFilter: function(value, type) {
+      this.selectedFilters[type] = value;
+    },
   },
 };
 </script>

--- a/src/views/TaskOverview.vue
+++ b/src/views/TaskOverview.vue
@@ -1,5 +1,22 @@
 <template>
   <page-with-drawer :is-drawer-open="isDrawerOpen">
+    <div class="text-center my-8">
+      <h1>
+        Find roles at
+        <strong class="xr-title">
+          Extinction Rebellion Nederland.
+        </strong>
+      </h1>
+    </div>
+    <div v-if="$vuetify.breakpoint.smAndDown" class="mb-8">
+      <v-divider />
+      <div class="d-flex justify-end pa-3">
+        <v-btn text color="primary" @click="isDrawerOpen = true">
+          Filter
+        </v-btn>
+      </div>
+      <v-divider />
+    </div>
     <grid-list
       v-if="filteredTasks.length > 0"
       item-width="300px"

--- a/src/views/TaskOverview.vue
+++ b/src/views/TaskOverview.vue
@@ -2,7 +2,7 @@
   <page-with-drawer :is-drawer-open="isDrawerOpen">
     <div class="text-center my-8">
       <h1>
-        Find roles at
+        Find tasks at
         <strong class="xr-title">
           Extinction Rebellion Nederland.
         </strong>
@@ -17,12 +17,7 @@
       </div>
       <v-divider />
     </div>
-    <grid-list
-      v-if="filteredTasks.length > 0"
-      item-width="300px"
-      item-height="200px"
-      gap="2rem"
-    >
+    <grid-list v-if="filteredTasks.length > 0" gap="2rem">
       <task-card v-for="task in filteredTasks" :key="task.id" :task="task" />
     </grid-list>
     <div v-else class="pa-5 text-center">
@@ -30,13 +25,20 @@
       <p>Try removing filters.</p>
     </div>
     <template v-slot:drawer>
-      <default-drawer>
+      <default-drawer @close-drawer="handleCloseDrawer">
         <template #header>
           <div
             class="d-flex justify-space-between align-center"
             style="width:100%;"
           >
-            <span class="font-weight-bold">Search for positions</span>
+            <div class="d-flex flex-column">
+              <span class="font-weight-bold">
+                Search for tasks
+              </span>
+              <span class="font-weight-light">
+                ({{ filteredTasks.length }} tasks found)
+              </span>
+            </div>
             <v-btn text color="primary">
               Clear filters
             </v-btn>
@@ -95,6 +97,9 @@ export default {
   methods: {
     handleSelectFilter: function(value, type) {
       this.selectedFilters[type] = value;
+    },
+    handleCloseDrawer: function() {
+      this.isDrawerOpen = false;
     },
   },
 };


### PR DESCRIPTION
I got a bit carried away (as i tend to do), so this is kind of a big one. 

- Added a task overview page at /tasks, no links yet, so you'll have to type it in manually for now
- The list uses the same filters from the role overview, they're similar now, but they may diverge at some point. I just copy-pasted it for now, no need for unnecessary abstractions yet.
- Since this is very similar to the Role overview, i extracted a few components that were fairly reusable:
  - A default card, with title, subtitle, content, and action slots
  - A default drawer, with title slot and a close button
  - A page with drawer, which should take care of rendering the drawer, just pass the `isDrawerOpen` prop
  - A grid list, which uses css grid, to make the cards line up nicely

I'm not sure if i like the interface for the DefaultCard, if anyone has some opinions on this, please let me know.
Solves #6 