### PR TITLE
Do not create/edit role/task on enter

### DIFF
--- a/src/components/roles/NewRoleDialog.vue
+++ b/src/components/roles/NewRoleDialog.vue
@@ -5,7 +5,7 @@
       <validation-observer ref="form" v-slot="{ invalid, handleSubmit }">
         <form
           @submit.prevent="handleSubmit(publishRole)"
-          @keydown.enter.prevent
+          @keypress.enter.prevent
         >
           <validation-provider
             v-slot="{ errors }"

--- a/src/components/roles/NewRoleDialog.vue
+++ b/src/components/roles/NewRoleDialog.vue
@@ -3,7 +3,10 @@
     <v-card class="pa-4">
       <h2>New role</h2>
       <validation-observer ref="form" v-slot="{ invalid, handleSubmit }">
-        <form @submit.prevent="handleSubmit(publishRole)">
+        <form
+          @submit.prevent="handleSubmit(publishRole)"
+          @keydown.enter.prevent
+        >
           <validation-provider
             v-slot="{ errors }"
             rules="required|alpha_spaces|max:30"

--- a/src/components/roles/RoleEditDialog.vue
+++ b/src/components/roles/RoleEditDialog.vue
@@ -5,7 +5,7 @@
     <v-card class="pa-4">
       <h2>Edit role</h2>
       <validation-observer ref="form" v-slot="{ invalid, handleSubmit }">
-        <form @submit.prevent="handleSubmit(onEditRole)">
+        <form @submit.prevent="handleSubmit(onEditRole)" @keydown.enter.prevent>
           <validation-provider
             v-slot="{ errors }"
             rules="required|alpha_spaces|max:30"

--- a/src/components/tasks/NewTaskDialog.vue
+++ b/src/components/tasks/NewTaskDialog.vue
@@ -3,7 +3,10 @@
     <v-card class="pa-4">
       <h2>New Task</h2>
       <validation-observer ref="form" v-slot="{ invalid, handleSubmit }">
-        <form @submit.prevent="handleSubmit(publishTask)">
+        <form
+          @submit.prevent="handleSubmit(publishTask)"
+          @keydown.enter.prevent
+        >
           <validation-provider
             v-slot="{ errors }"
             rules="required|alpha_spaces|max:30"


### PR DESCRIPTION
## What changes have been made? 

Override the default behavior of submitting the create / edit role forms by pressing enter

### Issues resolved by these changes

Resolves #53 

## Additional comments

See https://stackoverflow.com/questions/44261073/vuejs-how-to-prevent-form-submit-on-enter-but-still-save-work-in-inputs
