### PR TITLE
Stop button overflowing container if long title

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,10 @@
         }
       }
     ],
-    "plugins": ["vue", "prettier"]
+    "plugins": [
+      "vue",
+      "prettier"
+    ]
   },
   "prettier": {
     "semi": true,
@@ -119,7 +122,10 @@
       "autoprefixer": {}
     }
   },
-  "browserslist": ["> 1%", "last 2 versions"],
+  "browserslist": [
+    "> 1%",
+    "last 2 versions"
+  ],
   "jest": {
     "preset": "@vue/cli-plugin-unit-jest"
   }

--- a/src/components/surfaces/DefaultCard.vue
+++ b/src/components/surfaces/DefaultCard.vue
@@ -30,7 +30,7 @@
               <slot name="content" />
             </v-card-text>
           </div>
-          <div class="d-flex flex-wrap justify-space-between align-end mt-5">
+          <div class="d-flex flex-wrap justify-space-between align-end">
             <span class="d-flex flex-column justify-center">
               <slot name="meta" />
             </span>


### PR DESCRIPTION
Rather than change the title size, I removed the margin because it
doesn't affect display of components with short titles.

Fixes #84

## What changes have been made? 

If you have changed the interface please include screenshots of before and after. 

## Rationale for these changes

### Issues resolved by these changes

Resolves #84 

## Additional comments

Please explain difficult parts of your code to make it easier to review your pull request.  

