### PR TITLE
easy clearing of filter options

### DIFF
--- a/src/components/AutocompleteCustom.vue
+++ b/src/components/AutocompleteCustom.vue
@@ -6,6 +6,7 @@
     item-text="title"
     chips
     small-chips
+    deletable-chips
     multiple
     class="mt-3"
     :label="label"

--- a/src/components/roles/RoleFilters.vue
+++ b/src/components/roles/RoleFilters.vue
@@ -7,6 +7,7 @@
         placeholder="Facilitator, Writer, Photographer..."
         class="mt-3"
         @input="debounceSearchUpdate"
+        clearable
       />
     </div>
     <filter-section>
@@ -74,7 +75,8 @@ export default {
   methods: {
     ...mapActions("roles", ["setFilter"]),
     debounceSearchUpdate: debounce(function($event) {
-      this.setFilter({ filterType: "search", filterValue: $event });
+      const filterValue = $event ? $event : "";
+      this.setFilter({ filterType: "search", filterValue });
     }, 500),
   },
 };


### PR DESCRIPTION

## What changes have been made? 

Correct props have been added to the Vuetify elements. RoleFilters input can now be cleared with cross, local group and working circle field selections can be removed with cross.

**Before:** 
![before](https://user-images.githubusercontent.com/51111316/97108473-18cb9000-16ce-11eb-8064-0da9a5c09fe0.JPG)

**After:**
![after](https://user-images.githubusercontent.com/51111316/97108474-1cf7ad80-16ce-11eb-99d8-5b0e127d5f2f.JPG)


## Rationale for these changes

### Issues resolved by these changes

Resolves #55 

## Additional comments

The clear button on the RoleFilters sets the field to null when clicked. The filtering does not work when the input is null, only when it's "" (empty string). I added a check on the filterValue that sets it to "" if it's null in order to fix this issue. 

