### PR TITLE
Force validation of responsibilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,24 +108,19 @@
         }
       }
     ],
-    "plugins": [
-      "vue",
-      "prettier"
-    ]
+    "plugins": ["vue", "prettier"]
   },
   "prettier": {
     "semi": true,
-    "trailingComma": "es5"
+    "trailingComma": "es5",
+    "arrowParens": "avoid"
   },
   "postcss": {
     "plugins": {
       "autoprefixer": {}
     }
   },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions"
-  ],
+  "browserslist": ["> 1%", "last 2 versions"],
   "jest": {
     "preset": "@vue/cli-plugin-unit-jest"
   }

--- a/src/components/roles/RoleEditDialog.vue
+++ b/src/components/roles/RoleEditDialog.vue
@@ -228,7 +228,15 @@ extend("requiredSelect", {
   message: "You must select a {_field_}.",
 });
 extend("requiredList", {
-  validate: () => false,
+  validate: () => {
+    return {
+      valid: false,
+      data: {
+        required: false,
+      },
+    };
+  },
+  computesRequired: true,
   message: "You must add at least one {_field_}.",
 });
 extend("email", { ...email, message: "You must enter a valid email address." });


### PR DESCRIPTION
## What changes have been made? 

Changed the validation of role responsibilities so that it always performs the validation, even when the input validation is empty. This way, the user cannot submit a new role if they haven't added any responsibilities.

This precisely how [the documentation](https://vee-validate.logaretm.com/v2/guide/custom-rules.html#require-like-rules) instructs writing require-like rules.

## Rationale for these changes

Resolves #52 

