### PR TITLE
fixed padding on role cards and views

### DIFF
--- a/src/components/roles/RoleCard.vue
+++ b/src/components/roles/RoleCard.vue
@@ -37,7 +37,7 @@ export default {
   components: {
     DefaultCard,
   },
-    props: {
+  props: {
     role: {
       type: Object,
       required: true,
@@ -54,4 +54,8 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.v-card {
+  padding: 10px;
+}
+</style>

--- a/src/components/roles/RoleViewDialog.vue
+++ b/src/components/roles/RoleViewDialog.vue
@@ -245,6 +245,8 @@ export default {
 </script>
 <style lang="scss">
 .v-card {
+  padding: 10px;
+
   &.theme--light {
     .v-card__text {
       color: #222;

--- a/src/components/surfaces/DefaultCard.vue
+++ b/src/components/surfaces/DefaultCard.vue
@@ -2,7 +2,7 @@
   <v-hover v-slot:default="{ hover }">
     <v-card
       width="300"
-      height="180"
+      height="200"
       class="card"
       :class="`bg-${color}`"
       v-bind="$attrs"

--- a/src/components/tasks/TaskViewDialog.vue
+++ b/src/components/tasks/TaskViewDialog.vue
@@ -180,6 +180,8 @@ export default {
 </script>
 <style lang="scss" scoped>
 .v-card {
+  padding: 10px;
+
   &.theme--light {
     .v-card__text {
       color: #222;


### PR DESCRIPTION
## What changes have been made? 

Added 10px of padding to the role cards and views. Made role cards 20px higher (now 200px)

**Before:**
![before1](https://user-images.githubusercontent.com/51111316/97910966-d697f380-1d4a-11eb-8ae1-4d8292d6b864.JPG)
![before2](https://user-images.githubusercontent.com/51111316/97910977-dac41100-1d4a-11eb-9262-787c8d2b8668.JPG)

**After:**
![after1](https://user-images.githubusercontent.com/51111316/97911000-e283b580-1d4a-11eb-956a-c93e3d406dab.JPG)
![after2](https://user-images.githubusercontent.com/51111316/97911007-e4e60f80-1d4a-11eb-9a02-47f266f2cdad.JPG)


## Rationale for these changes

I added padding to make the cards and views feel less cramped. The role cards have been made 20px higher to account for the extra padding.

### Issues resolved by these changes

Resolves #92 




