### PR TITLE
Make Mattermost id required

### DIFF
--- a/src/components/roles/RoleEditDialog.vue
+++ b/src/components/roles/RoleEditDialog.vue
@@ -162,13 +162,13 @@ This can include information about the circle or the specific project that the r
           </validation-provider>
           <validation-provider
             v-slot="{ errors }"
-            name="Mattermost Id"
+            name="Mattermost id"
             mode="eager"
-            rules="mattermost|max:50"
+            rules="required|mattermost|max:50"
           >
             <v-text-field
               v-model="role.mattermostId"
-              label="Mattermost id (optional)"
+              label="Mattermost id"
               :error-messages="errors"
             />
           </validation-provider>


### PR DESCRIPTION
## What changes have been made? 

Make it required for rebels to enter a Mattermost Id when creating a new role

## Rationale for these changes

* Promote the use of our internal communication platform
* Verify the identity of role publishers
* Easily get in contact with role publishers (and send the automatic notifications through the Mattermost API)
