### PR TITLE
Feature/new layout filter 156

### DIFF
--- a/src/components/AutocompleteCustom.vue
+++ b/src/components/AutocompleteCustom.vue
@@ -1,13 +1,12 @@
 <template>
-  <v-autocomplete
+  <v-select
     :items="items"
     :value="selectedItemsIds"
     item-value="id"
     :item-text="itemText"
-    chips
-    small-chips
-    deletable-chips
     multiple
+    outlined
+    :hide-details="hideDetails"
     class="mt-3"
     :label="label"
     @change="$emit('change', $event)"
@@ -20,6 +19,10 @@ import { isArrayValid } from "@/utils/validators";
 export default {
   name: "AutocompleteCustom",
   props: {
+    hideDetails: {
+      type: Boolean,
+      required: false
+    },
     items: {
       type: Array,
       required: true

--- a/src/components/AutocompleteCustom.vue
+++ b/src/components/AutocompleteCustom.vue
@@ -1,13 +1,15 @@
 <template>
-  <v-select
+  <v-autocomplete
     :items="items"
     :value="selectedItemsIds"
     item-value="id"
     :item-text="itemText"
-    multiple
     outlined
+    chips
+    small-chips
+    deletable-chips
+    multiple
     :hide-details="hideDetails"
-    class="mt-3"
     :label="label"
     @change="$emit('change', $event)"
   />

--- a/src/components/layout/DefaultDrawer.vue
+++ b/src/components/layout/DefaultDrawer.vue
@@ -33,11 +33,20 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.drawer-header,
+.drawer-content {
+  padding: 0.75rem;
+  @media (min-width: $breakpoint-sm) {
+    padding: 1rem;
+  }
+}
+
 .drawer-header {
   display: flex;
   align-items: center;
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-  padding: 0.5rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 }
 
 .theme--dark {
@@ -46,7 +55,6 @@ export default {
   }
 }
 .drawer-content {
-  padding: 0.5rem;
   &__button-back {
     margin-top: $distance-sm;
   }

--- a/src/components/layout/DefaultDrawer.vue
+++ b/src/components/layout/DefaultDrawer.vue
@@ -7,19 +7,21 @@
       "
       class="drawer-header"
     >
-      <v-btn
-        v-if="this.$vuetify.breakpoint.smAndDown"
-        icon
-        @click="$emit('close-drawer', false)"
-      >
-        <v-icon color="primary">
-          mdi-arrow-left
-        </v-icon>
-      </v-btn>
       <slot name="header" />
     </div>
     <div class="drawer-content">
       <slot />
+      <v-btn
+        v-if="this.$vuetify.breakpoint.smAndDown"
+        fab
+        class="drawer-content__button-back"
+        color="primary"
+        @click="$emit('close-drawer', false)"
+      >
+        <v-icon>
+          mdi-arrow-left
+        </v-icon>
+      </v-btn>
     </div>
   </div>
 </template>
@@ -45,5 +47,8 @@ export default {
 }
 .drawer-content {
   padding: 0.5rem;
+  &__button-back {
+    margin-top: $distance-sm;
+  }
 }
 </style>

--- a/src/components/layout/PageWithDrawer.vue
+++ b/src/components/layout/PageWithDrawer.vue
@@ -60,6 +60,7 @@ export default {
   transform: translateX(100%);
   &.active {
     transform: translateX(0);
+    z-index: 99;
   }
   .theme--light & {
     background: white;

--- a/src/components/roles/RoleFilters.vue
+++ b/src/components/roles/RoleFilters.vue
@@ -1,44 +1,36 @@
 <template>
   <div>
-    <div>
-      <v-text-field
-        :value="selectedFilters.search"
-        :label="$t('Search by role title')"
-        :placeholder="$t('Facilitator, Writer, Photographer...')"
-        class="mt-3"
-        clearable
-        @input="debounceSearchUpdate"
+    <v-text-field
+      :value="selectedFilters.search"
+      :label="$t('Search by role title')"
+      :placeholder="$t('Facilitator, Writer, Photographer...')"
+      clearable
+      outlined
+      append-icon="mdi-magnify"
+      @input="debounceSearchUpdate"
+    >
+    </v-text-field>
+    <flex-wrapper direction="column">
+      <h4>{{ $t("Groups") }}</h4>
+      <autocomplete-custom
+        :items="localGroups"
+        :selected-items-ids="selectedFilters.localGroups"
+        :label="$t('Local Group')"
+        :hideDetails="true"
+        item-text="title"
+        @change="setFilter({ filterType: 'localGroups', filterValue: $event })"
       />
-    </div>
-    <filter-section>
-      <template v-slot:title>
-        {{ $t("Groups") }}
-      </template>
-      <flex-wrapper direction="column">
-        <autocomplete-custom
-          :items="localGroups"
-          :selected-items-ids="selectedFilters.localGroups"
-          :label="$t('Local Group')"
-          item-text="title"
-          @change="
-            setFilter({ filterType: 'localGroups', filterValue: $event })
-          "
-        />
-        <autocomplete-custom
-          :items="workingCircles"
-          :selected-items-ids="selectedFilters.workingCircles"
-          :label="$t('Working circle')"
-          :item-text="['title', $i18n.locale]"
-          @change="
-            setFilter({ filterType: 'workingCircles', filterValue: $event })
-          "
-        />
-      </flex-wrapper>
-    </filter-section>
-    <filter-section>
-      <template v-slot:title>
-        {{ $t("Time commitment") }}
-      </template>
+      <autocomplete-custom
+        :items="workingCircles"
+        :selected-items-ids="selectedFilters.workingCircles"
+        :label="$t('Working circle')"
+        :item-text="['title', $i18n.locale]"
+        outlined
+        @change="
+          setFilter({ filterType: 'workingCircles', filterValue: $event })
+        "
+      />
+      <h4>{{ $t("Time Commitment") }}</h4>
       <v-range-slider
         :value="selectedFilters.timeCommitment"
         :min="timeCommitmentRange.min"
@@ -48,22 +40,31 @@
         :label="$t('Time Commitment')"
         @end="setFilter({ filterType: 'timeCommitment', filterValue: $event })"
       />
-    </filter-section>
+    </flex-wrapper>
+    <v-btn
+      v-if="isUsingFilters"
+      class="delete-filter-btn"
+      depressed
+      @click="setDefaultFilters"
+    >
+      {{ $t("Clear filters") }}
+      <v-icon>
+        mdi-delete
+      </v-icon>
+    </v-btn>
   </div>
 </template>
 
 <script>
 import FlexWrapper from "@/components/layout/FlexWrapper.vue";
 import AutocompleteCustom from "@/components/AutocompleteCustom.vue";
-import { mapState, mapActions } from "vuex";
+import { mapState, mapActions, mapGetters } from "vuex";
 import debounce from "lodash/debounce";
 import { timeCommitmentRange } from "@/constants/timeCommitments";
-import FilterDrawerSection from "../layout/FilterDrawerSection.vue";
 
 export default {
   name: "RoleFilters",
   components: {
-    filterSection: FilterDrawerSection,
     AutocompleteCustom,
     FlexWrapper
   },
@@ -72,13 +73,16 @@ export default {
   }),
   computed: {
     ...mapState("groups", ["localGroups", "workingCircles"]),
-    ...mapState("roles", ["selectedFilters"])
+    ...mapState("roles", ["selectedFilters"]),
+    ...mapGetters({
+      isUsingFilters: "roles/isUsingFilters"
+    })
   },
   beforeMount() {
     this.$store.dispatch("roles/setDefaultFilters");
   },
   methods: {
-    ...mapActions("roles", ["setFilter"]),
+    ...mapActions("roles", ["setFilter", "setDefaultFilters"]),
     debounceSearchUpdate: debounce(function($event) {
       const filterValue = $event || "";
       this.setFilter({ filterType: "search", filterValue });
@@ -87,4 +91,9 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.delete-filter-btn {
+  margin-top: 1rem;
+  float: right;
+}
+</style>

--- a/src/components/roles/RoleFilters.vue
+++ b/src/components/roles/RoleFilters.vue
@@ -42,7 +42,7 @@
       />
     </flex-wrapper>
     <v-btn
-      v-if="isUsingFilters"
+      :disabled="!isUsingFilters"
       class="delete-filter-btn"
       depressed
       @click="setDefaultFilters"

--- a/src/components/roles/RoleFilters.vue
+++ b/src/components/roles/RoleFilters.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="role-filters">
     <v-text-field
       :value="selectedFilters.search"
       :label="$t('Search by role title')"
@@ -11,8 +11,9 @@
     >
     </v-text-field>
     <flex-wrapper direction="column">
-      <h4>{{ $t("Groups") }}</h4>
+      <h4 class="heading">{{ $t("Groups") }}</h4>
       <autocomplete-custom
+        class="group-dropdown-first"
         :items="localGroups"
         :selected-items-ids="selectedFilters.localGroups"
         :label="$t('Local Group')"
@@ -38,6 +39,7 @@
         class="mt-12"
         thumb-label="always"
         :label="$t('Time Commitment')"
+        hide-details
         @end="setFilter({ filterType: 'timeCommitment', filterValue: $event })"
       />
     </flex-wrapper>
@@ -95,5 +97,13 @@ export default {
 .delete-filter-btn {
   margin-top: 1rem;
   float: right;
+}
+.role-filters {
+  .heading {
+    margin-bottom: 0.5rem;
+  }
+  .group-dropdown-first {
+    margin-bottom: 1rem;
+  }
 }
 </style>

--- a/src/views/RolesOverview.vue
+++ b/src/views/RolesOverview.vue
@@ -4,18 +4,22 @@
     <role-edit-dialog v-model="newRoleDialog" />
     <div v-if="isMobile" class="mb-8">
       <v-divider />
-      <div class="d-flex justify-space-between pa-3">
-        <new-item-button
-          v-if="loggedIn"
-          :text="$t('New Role')"
-          @click="showNewRoleDialog"
-        />
-        <v-btn text color="primary" @click="isDrawerOpen = true">
-          {{ $t("Filter") }}
-        </v-btn>
+      <div class="d-flex justify-space-between pa-3" v-if="loggedIn">
+        <new-item-button :text="$t('New Role')" @click="showNewRoleDialog" />
       </div>
       <v-divider />
     </div>
+    <v-btn
+      class="filter-btn"
+      color="primary"
+      v-if="!isDrawerOpen"
+      @click="isDrawerOpen = true"
+      rounded
+      x-large
+    >
+      {{ $t("Filter") }}
+      <v-icon>mdi-magnify</v-icon>
+    </v-btn>
     <transition name="fade" mode="out-in">
       <grid-list v-if="!!roles.length" key="roles" gap="1rem">
         <role-card
@@ -166,3 +170,15 @@ export default {
   }
 };
 </script>
+<style lang="scss" scoped>
+.filter-btn {
+  position: fixed;
+  background: $xr-angry;
+  right: $distance-sm;
+  bottom: $distance-sm;
+  z-index: 80;
+  @media (min-width: $breakpoint-sm) {
+    display: none;
+  }
+}
+</style>

--- a/src/views/RolesOverview.vue
+++ b/src/views/RolesOverview.vue
@@ -76,18 +76,15 @@
             style="width:100%;"
           >
             <div class="d-flex flex-column">
-              <span class="font-weight-bold">
+              <h3 class="font-weight-bold">
                 {{ $t("Search for positions") }}
-              </span>
+              </h3>
               <span v-if="isMobile" class="font-weight-light">
                 (<span v-if="!isLoadingRoles">{{ roles.length }}</span>
                 <span v-else>...</span>
                 {{ $t("positions found") }})
               </span>
             </div>
-            <v-btn text color="primary" @click="setDefaultFilters">
-              {{ $t("Clear filters") }}
-            </v-btn>
           </div>
         </template>
         <role-filters />


### PR DESCRIPTION
## What changes have been made? 

**Before**: the button hangs still at the top:
![Schermafbeelding 2021-05-03 om 12 02 59](https://user-images.githubusercontent.com/4222167/116864078-92a57e80-ac07-11eb-84cc-282dcae57f67.png)

**After**: the button hangs at the bottom:
![Schermafbeelding 2021-05-03 om 11 50 29](https://user-images.githubusercontent.com/4222167/116864084-93d6ab80-ac07-11eb-823a-f058252d25dd.png)

**Before**: here the back button in the filter is difficult to find:
![Schermafbeelding 2021-05-03 om 12 03 14](https://user-images.githubusercontent.com/4222167/116864246-d9937400-ac07-11eb-8c3e-b10fba750469.png)

** After **: here the back button is located at the bottom and easier to find:
![Schermafbeelding 2021-05-03 om 11 50 38](https://user-images.githubusercontent.com/4222167/116864291-eca64400-ac07-11eb-964b-962231dff0c3.png)


## Rationale for these changes

- It was very unclear for users how to filter the search results.
- Both buttons were located at the top, which is harder to tap for mobile users.

### Issues resolved by these changes

Resolves #156 

## Additional comments

Quite straightforward!
