### PR TITLE
Fixed no-results text behind background image (closes #164).

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -30,3 +30,7 @@
 .v-content {
   margin-top: $nav-bar-height;
 }
+
+.fix-z-index {
+  position: relative;
+}

--- a/src/views/RolesOverview.vue
+++ b/src/views/RolesOverview.vue
@@ -38,7 +38,7 @@
       <div
         v-if="!roles.length && !isLoadingRoles"
         key="noRoles"
-        class="pa-5 text-center"
+        class="pa-5 text-center fix-z-index"
       >
         <div v-if="isUsingFilters">
           <h3>{{ $t("No results.") }}</h3>


### PR DESCRIPTION
Because div had no position property z-indexes where not working. Fixed by adding a special fix class.

## What changes have been made? 

See comment for screenshots.

## Rationale for these changes

When elements have no position attribute, z-index doesn't work.

### Issues resolved by these changes

Resolves #164 

## Additional comments

The solution could maybe be improved by using vuetify element. I expect no z-index issues in that case.

